### PR TITLE
add site building workflow

### DIFF
--- a/.github/workflows/build-site.yaml
+++ b/.github/workflows/build-site.yaml
@@ -1,0 +1,29 @@
+name: "Rebuild Site"
+on:
+  workflow_dispatch:
+    inputs:
+      publish:
+        description: "Push Data to branch (uncheck for a dry run)"
+        type: boolean
+        required: false
+        default: true
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  site:
+    uses: hubverse-org/hub-dashboard-control-room/.github/workflows/generate-site.yaml@main
+    with:
+      owner: '${{ github.event.repository.owner.login }}'
+      name: '${{ github.event.repository.name }}'
+      slug: '${{ github.event.repository.owner.login }}'
+      email: '${{ github.event.repository.owner.id }}+${{ github.event.repository.owner.login }}@users.noreply.github.com'
+      publish: ${{ inputs.publish || github.event_name == 'push' }}
+    secrets:
+      id: 'none'
+      key: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This repository previously was using the GitHub app from the control room to build the site.

While the maintenance burden of a GitHub app is relatively low, it is not worth the cost of the extra cognitive load on the remaining developers in the lab, and this pull request will allow me to decommission the bot all together.
