### PR TITLE
Remove testthat.R from tests directory to fix recursive test execution

### DIFF
--- a/src/dashboard/tests/testthat.R
+++ b/src/dashboard/tests/testthat.R
@@ -1,7 +1,0 @@
-# Test Runner for Dashboard Tests
-# ================================
-# Run with: testthat::test_dir("src/dashboard/tests")
-
-library(testthat)
-
-test_dir(here::here("src/dashboard/tests"))


### PR DESCRIPTION
The testthat.R file was being discovered as a test file by test_dir(), causing it to recursively call test_dir() and eventually fail with "NA/NaN argument" errors after running tests hundreds of times.