### PR TITLE
Separate testing from data generation workflow

### DIFF
--- a/.github/workflows/build-data.yaml
+++ b/.github/workflows/build-data.yaml
@@ -20,6 +20,16 @@ on:
         type: boolean
         required: false
         default: false
+      generate_forecasts:
+        description: "Generate forecast data"
+        type: boolean
+        required: false
+        default: true
+      generate_targets:
+        description: "Generate target data"
+        type: boolean
+        required: false
+        default: true
       publish:
         description: "Push data to dashboard-data branch"
         type: boolean
@@ -62,30 +72,32 @@ jobs:
             any::readr
             any::tibble
             any::arrow
-            any::testthat
             github::hubverse-org/hubData
             github::hubverse-org/hubUtils
-
-      - name: Run tests
-        run: |
-          testthat::test_dir("src/dashboard/tests", stop_on_failure = TRUE)
-        shell: Rscript {0}
 
       - name: Generate data
         env:
           NOWCAST_DATES: ${{ inputs.nowcast_dates }}
           REGENERATE: ${{ inputs.regenerate }}
+          GENERATE_FORECASTS: ${{ inputs.generate_forecasts }}
+          GENERATE_TARGETS: ${{ inputs.generate_targets }}
         run: |
           source("src/dashboard/pipeline.R")
 
           nowcast_dates <- Sys.getenv("NOWCAST_DATES", "")
           regenerate <- as.logical(Sys.getenv("REGENERATE", "FALSE"))
+          generate_forecasts <- as.logical(Sys.getenv("GENERATE_FORECASTS", "TRUE"))
+          generate_targets <- as.logical(Sys.getenv("GENERATE_TARGETS", "TRUE"))
 
           if (is.na(regenerate)) regenerate <- FALSE
+          if (is.na(generate_forecasts)) generate_forecasts <- TRUE
+          if (is.na(generate_targets)) generate_targets <- TRUE
 
           run_pipeline(
             nowcast_dates = if (nowcast_dates == "") NULL else nowcast_dates,
-            regenerate = regenerate
+            regenerate = regenerate,
+            generate_forecasts = generate_forecasts,
+            generate_targets = generate_targets
           )
         shell: Rscript {0}
 
@@ -99,28 +111,38 @@ jobs:
 
       - name: Copy generated data to branch
         if: ${{ inputs.publish != false }}
+        env:
+          GENERATE_FORECASTS: ${{ inputs.generate_forecasts }}
+          GENERATE_TARGETS: ${{ inputs.generate_targets }}
         run: |
           # Create directories if they don't exist
           mkdir -p data-branch/forecasts
           mkdir -p data-branch/targets/round-open
           mkdir -p data-branch/targets/latest
 
-          # Copy new data files
-          if [ -d "output/forecasts" ]; then
+          # Copy forecast files if forecasts were generated
+          if [ "$GENERATE_FORECASTS" != "false" ] && [ -d "output/forecasts" ]; then
             cp -r output/forecasts/* data-branch/forecasts/ 2>/dev/null || true
+            echo "Copied forecast files"
           fi
 
-          if [ -d "output/targets/round-open" ]; then
-            cp -r output/targets/round-open/* data-branch/targets/round-open/ 2>/dev/null || true
+          # Copy target files if targets were generated
+          if [ "$GENERATE_TARGETS" != "false" ]; then
+            if [ -d "output/targets/round-open" ]; then
+              cp -r output/targets/round-open/* data-branch/targets/round-open/ 2>/dev/null || true
+              echo "Copied round-open target files"
+            fi
+
+            if [ -d "output/targets/latest" ]; then
+              cp -r output/targets/latest/* data-branch/targets/latest/ 2>/dev/null || true
+              echo "Copied latest target files"
+            fi
           fi
 
-          if [ -d "output/targets/latest" ]; then
-            cp -r output/targets/latest/* data-branch/targets/latest/ 2>/dev/null || true
-          fi
-
-          # Copy dashboard options
+          # Copy dashboard options (always updated)
           if [ -f "output/dashboard-options.json" ]; then
             cp output/dashboard-options.json data-branch/
+            echo "Copied dashboard-options.json"
           fi
 
           echo "Data files copied successfully"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,59 @@
+name: "Run Tests"
+
+# Run tests on push, PR, and manual trigger.
+# This ensures code changes are validated before merging.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'src/dashboard/**'
+      - '.github/workflows/test.yaml'
+
+  pull_request:
+    branches: [main]
+    paths:
+      - 'src/dashboard/**'
+      - '.github/workflows/test.yaml'
+
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup R
+        uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: '4.3'
+          use-public-rspm: true
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libcurl4-openssl-dev libssl-dev libxml2-dev
+
+      - name: Install R dependencies
+        uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          packages: |
+            any::here
+            any::dplyr
+            any::tidyr
+            any::lubridate
+            any::jsonlite
+            any::readr
+            any::tibble
+            any::arrow
+            any::testthat
+            github::hubverse-org/hubData
+            github::hubverse-org/hubUtils
+
+      - name: Run unit tests
+        run: |
+          testthat::test_dir("src/dashboard/tests", stop_on_failure = TRUE)
+        shell: Rscript {0}

--- a/src/dashboard/export.R
+++ b/src/dashboard/export.R
@@ -248,6 +248,8 @@ export_options_json <- function(
 #' @param as_of_round_open Date string for round-open data
 #' @param as_of_latest Date string for latest data
 #' @param output_dir Output directory
+#' @param generate_forecasts If TRUE, export forecast files (default TRUE)
+#' @param generate_targets If TRUE, export target files (default TRUE)
 #' @return List with counts of exported files
 export_nowcast_date <- function(
     means,
@@ -258,7 +260,9 @@ export_nowcast_date <- function(
     nowcast_date,
     as_of_round_open,
     as_of_latest,
-    output_dir
+    output_dir,
+    generate_forecasts = TRUE,
+    generate_targets = TRUE
 ) {
   locations <- unique(means$location)
 
@@ -268,37 +272,41 @@ export_nowcast_date <- function(
 
   for (loc in locations) {
     # Export forecast
-    result <- export_forecast_json(
-      means = means,
-      quantiles = quantiles,
-      multinomial_pi = multinomial_pi,
-      location = loc,
-      nowcast_date = nowcast_date,
-      output_dir = output_dir
-    )
-    if (!is.null(result)) forecast_count <- forecast_count + 1
+    if (generate_forecasts) {
+      result <- export_forecast_json(
+        means = means,
+        quantiles = quantiles,
+        multinomial_pi = multinomial_pi,
+        location = loc,
+        nowcast_date = nowcast_date,
+        output_dir = output_dir
+      )
+      if (!is.null(result)) forecast_count <- forecast_count + 1
+    }
 
     # Export round-open targets
-    result <- export_target_json(
-      target_data = target_data_round_open,
-      location = loc,
-      nowcast_date = nowcast_date,
-      as_of_date = as_of_round_open,
-      version = "round-open",
-      output_dir = output_dir
-    )
-    if (!is.null(result)) target_round_open_count <- target_round_open_count + 1
+    if (generate_targets) {
+      result <- export_target_json(
+        target_data = target_data_round_open,
+        location = loc,
+        nowcast_date = nowcast_date,
+        as_of_date = as_of_round_open,
+        version = "round-open",
+        output_dir = output_dir
+      )
+      if (!is.null(result)) target_round_open_count <- target_round_open_count + 1
 
-    # Export latest targets
-    result <- export_target_json(
-      target_data = target_data_latest,
-      location = loc,
-      nowcast_date = nowcast_date,
-      as_of_date = as_of_latest,
-      version = "latest",
-      output_dir = output_dir
-    )
-    if (!is.null(result)) target_latest_count <- target_latest_count + 1
+      # Export latest targets
+      result <- export_target_json(
+        target_data = target_data_latest,
+        location = loc,
+        nowcast_date = nowcast_date,
+        as_of_date = as_of_latest,
+        version = "latest",
+        output_dir = output_dir
+      )
+      if (!is.null(result)) target_latest_count <- target_latest_count + 1
+    }
   }
 
   list(

--- a/src/dashboard/pipeline.R
+++ b/src/dashboard/pipeline.R
@@ -270,21 +270,31 @@ get_target_dates <- function(nowcast_date, days_back = 31, days_forward = 10) {
 #' Run the dashboard data pipeline
 #' @param nowcast_dates Character vector of dates to process (NULL for latest)
 #' @param regenerate If TRUE, regenerate all historical data
+#' @param generate_forecasts If TRUE, generate forecast data (default TRUE)
+#' @param generate_targets If TRUE, generate target data (default TRUE)
 #' @param initial_selected_models Models to show by default in dashboard
 #' @param output_dir Base output directory
 #' @return Invisibly returns list of processed dates
 run_pipeline <- function(
     nowcast_dates = NULL,
     regenerate = FALSE,
+    generate_forecasts = TRUE,
+    generate_targets = TRUE,
     initial_selected_models = DEFAULT_INITIAL_MODELS,
     output_dir = OUTPUT_DIR
 ) {
   message("Starting dashboard data pipeline...")
+  message("  Generate forecasts: ", generate_forecasts)
+  message("  Generate targets: ", generate_targets)
 
   # Create output directories
-  dir.create(file.path(output_dir, "forecasts"), recursive = TRUE, showWarnings = FALSE)
-  dir.create(file.path(output_dir, "targets", "round-open"), recursive = TRUE, showWarnings = FALSE)
-  dir.create(file.path(output_dir, "targets", "latest"), recursive = TRUE, showWarnings = FALSE)
+  if (generate_forecasts) {
+    dir.create(file.path(output_dir, "forecasts"), recursive = TRUE, showWarnings = FALSE)
+  }
+  if (generate_targets) {
+    dir.create(file.path(output_dir, "targets", "round-open"), recursive = TRUE, showWarnings = FALSE)
+    dir.create(file.path(output_dir, "targets", "latest"), recursive = TRUE, showWarnings = FALSE)
+  }
 
   # Fetch hub configuration
   message("Fetching hub configuration...")
@@ -424,7 +434,9 @@ run_pipeline <- function(
         nowcast_date = nowcast_date,
         as_of_round_open = round_open_as_of,
         as_of_latest = latest_as_of,
-        output_dir = output_dir
+        output_dir = output_dir,
+        generate_forecasts = generate_forecasts,
+        generate_targets = generate_targets
       )
 
       message("  Exported: ", export_counts$forecasts, " forecasts, ",

--- a/src/dashboard/tests/test-pipeline-integration.R
+++ b/src/dashboard/tests/test-pipeline-integration.R
@@ -23,6 +23,18 @@ skip_if_no_hub_connection <- function() {
   })
 }
 
+#' Get a historical date that's known to have data
+#' Uses a date from the middle of available dates to avoid issues with
+#' the most recent date not having submissions yet
+#' @param hub_config Hub configuration
+#' @return A historical nowcast date string
+get_reliable_test_date <- function(hub_config) {
+  all_dates <- get_nowcast_dates(hub_config)
+  # Use a date from the middle of available dates
+  # This ensures the date has model submissions
+  all_dates[ceiling(length(all_dates) / 2)]
+}
+
 # =============================================================================
 # Test 1: Incremental run produces complete dashboard-options.json
 # =============================================================================
@@ -39,8 +51,8 @@ test_that("incremental run produces complete dashboard-options.json", {
   hub_config <- fetch_hub_config()
   all_dates <- get_nowcast_dates(hub_config)
 
-  # Use a date from the middle of the available dates
-  test_date <- all_dates[ceiling(length(all_dates) / 2)]
+  # Use a historical date that's known to have data
+  test_date <- get_reliable_test_date(hub_config)
 
   message("Running incremental pipeline for single date: ", test_date)
 
@@ -112,10 +124,9 @@ test_that("dashboard-options.json has all required fields with correct structure
   dir.create(test_output_dir, recursive = TRUE, showWarnings = FALSE)
   on.exit(unlink(test_output_dir, recursive = TRUE), add = TRUE)
 
-  # Get a valid date
+  # Get hub config and use a reliable historical date
   hub_config <- fetch_hub_config()
-  all_dates <- get_nowcast_dates(hub_config)
-  test_date <- tail(all_dates, 1)
+  test_date <- get_reliable_test_date(hub_config)
 
   # Run pipeline
   run_pipeline(
@@ -240,10 +251,9 @@ test_that("pipeline creates forecast and target files for processed date", {
   dir.create(test_output_dir, recursive = TRUE, showWarnings = FALSE)
   on.exit(unlink(test_output_dir, recursive = TRUE), add = TRUE)
 
-  # Get a valid date
+  # Get hub config and use a reliable historical date
   hub_config <- fetch_hub_config()
-  all_dates <- get_nowcast_dates(hub_config)
-  test_date <- tail(all_dates, 1)
+  test_date <- get_reliable_test_date(hub_config)
 
   # Run pipeline
   run_pipeline(
@@ -289,4 +299,3 @@ test_that("pipeline creates forecast and target files for processed date", {
                 info = "Forecast should have at least one model")
   }
 })
-


### PR DESCRIPTION
## Summary

- Creates a new `test.yaml` workflow that runs tests on push/PR to main, separating CI validation from data generation
- Removes the test step from `build-data.yaml` so data generation is no longer blocked by test failures
- Adds `generate_forecasts` and `generate_targets` checkboxes (both default true) to allow regenerating just targets or just forecasts independently
- Fixes integration tests to use a historical date instead of the most recent date, preventing failures when the newest round has no submissions yet

Closes #82

## Test plan

- [ ] Verify the new `test.yaml` workflow runs on PR creation
- [ ] Verify `build-data.yaml` no longer includes a test step
- [ ] Verify the `generate_forecasts` and `generate_targets` checkboxes appear in the workflow dispatch UI
- [ ] Run the data workflow manually to confirm it works without the test step

🤖 Generated with [Claude Code](https://claude.com/claude-code)