### PR TITLE
Fix latest target data using actual available dates from repository

### DIFF
--- a/src/dashboard/config.R
+++ b/src/dashboard/config.R
@@ -9,6 +9,7 @@ HUB_CONFIG_URL <- "https://raw.githubusercontent.com/reichlab/variant-nowcast-hu
 # Target Data Configuration
 TARGET_DATA_BUCKET <- "https://covid-clade-counts.s3.amazonaws.com"
 TARGET_DATA_HUB_URL <- "https://raw.githubusercontent.com/reichlab/variant-nowcast-hub/main/target-data/time-series"
+TARGET_DATA_API_URL <- "https://api.github.com/repos/reichlab/variant-nowcast-hub/contents/target-data/time-series"
 
 # Maximum weeks after nowcast date that target data is available
 TARGET_DATA_MAX_WEEKS <- 13


### PR DESCRIPTION
## Summary

- Fixes the root cause of why regenerating target data didn't work: the pipeline was trying to fetch data for as_of dates that don't exist yet
- Adds fetch_available_as_of_dates() to query the GitHub API for actual available dates in the source repository
- Modifies get_latest_as_of_date() to use the most recent available date instead of calculating based on Sys.Date()
- Adds a warning when the latest available target data is more than a week old
- Optimizes the pipeline to fetch available dates once per run (instead of per nowcast date)

Fixes #85

## Root Cause Analysis

The previous get_latest_as_of_date() function calculated the as_of date based on Sys.Date(). When running on 2026-01-13, this would return 2026-01-07, but the latest available as_of date in the repository was 2026-01-06. Since the parquet file didn't exist, fetch_target_data() failed and fell back to using round-open data, making both versions identical.

## Test plan

- [ ] Run the pipeline locally with a test date to verify it fetches the correct latest as_of date
- [ ] Verify the warning appears if target data is stale (> 7 days old)
- [ ] Re-run the data generation workflow for affected dates to fix the dashboard

Generated with Claude Code