### PR TITLE
Fix scheduled workflow not publishing data and adjust run time

### DIFF
--- a/.github/workflows/build-data.yaml
+++ b/.github/workflows/build-data.yaml
@@ -5,8 +5,8 @@ name: "Rebuild Dashboard Data"
 
 on:
   schedule:
-    # Run every Thursday at 10:00 UTC (after hub round closes)
-    - cron: "0 10 * * 4"
+    # Run every Thursday at 14:00 UTC / 9:00 AM ET (after hub round closes)
+    - cron: "0 14 * * 4"
 
   workflow_dispatch:
     inputs:
@@ -102,7 +102,7 @@ jobs:
         shell: Rscript {0}
 
       - name: Checkout dashboard-data branch
-        if: ${{ inputs.publish != false }}
+        if: ${{ github.event_name == 'schedule' || inputs.publish != false }}
         uses: actions/checkout@v4
         with:
           ref: dashboard-data
@@ -110,7 +110,7 @@ jobs:
           fetch-depth: 0
 
       - name: Copy generated data to branch
-        if: ${{ inputs.publish != false }}
+        if: ${{ github.event_name == 'schedule' || inputs.publish != false }}
         env:
           GENERATE_FORECASTS: ${{ inputs.generate_forecasts }}
           GENERATE_TARGETS: ${{ inputs.generate_targets }}
@@ -148,7 +148,7 @@ jobs:
           echo "Data files copied successfully"
 
       - name: Commit and push data
-        if: ${{ inputs.publish != false }}
+        if: ${{ github.event_name == 'schedule' || inputs.publish != false }}
         run: |
           cd data-branch
           git config user.name "github-actions[bot]"


### PR DESCRIPTION
## Summary
- Fix bug where scheduled runs of `build-data.yaml` skip the publish steps (checkout, copy, commit/push) because the `inputs` context is empty for scheduled triggers, causing `inputs.publish != false` to evaluate unexpectedly
- Adjust cron schedule from 10:00 UTC (5am ET) to 14:00 UTC (9am ET)

## Test plan
- [ ] Trigger a manual workflow run with default settings to verify publish steps execute
- [ ] Verify next scheduled run (Thursday 9am ET) successfully publishes data to `dashboard-data` branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)