### PR TITLE
Refresh latest target data for recent rounds on each pipeline run

### DIFF
--- a/src/dashboard/pipeline.R
+++ b/src/dashboard/pipeline.R
@@ -540,6 +540,64 @@ run_pipeline <- function(
     })
   }
 
+  # Update latest target data for recent nowcast dates (last 13 weeks).
+  # The main loop above only processes new dates, but "latest" target data
+  # improves over time as more sequences are reported. This step refreshes
+  # the latest target files for all still-open rounds.
+  if (generate_targets) {
+    recent_dates <- all_nowcast_dates[!sapply(all_nowcast_dates, is_round_closed)]
+    dates_needing_latest_update <- setdiff(recent_dates, dates_to_process)
+
+    if (length(dates_needing_latest_update) > 0) {
+      message("\nUpdating latest target data for ",
+              length(dates_needing_latest_update), " recent nowcast date(s)...")
+
+      for (nowcast_date in dates_needing_latest_update) {
+        tryCatch({
+          predicted_clades <- get_clades_for_date(hub_config, nowcast_date)
+          latest_as_of <- get_latest_as_of_date(nowcast_date, available_as_of_dates)
+          min_date <- as.Date(nowcast_date) - 96
+          latest_max_date <- as.Date(latest_as_of)
+
+          message("  ", nowcast_date, " (as_of=", latest_as_of, ")")
+
+          target_data_latest <- fetch_target_data(
+            as_of_date = latest_as_of,
+            nowcast_date = nowcast_date,
+            predicted_clades = predicted_clades,
+            min_date = min_date,
+            max_date = latest_max_date
+          )
+
+          if (!is.null(target_data_latest) && nrow(target_data_latest) > 0) {
+            target_data_latest <- target_data_latest |>
+              dplyr::filter(location %in% locations)
+            target_data_latest_processed <- process_daily_target_data(target_data_latest)
+
+            for (loc in unique(target_data_latest_processed$location)) {
+              export_target_json(
+                target_data = target_data_latest_processed,
+                location = loc,
+                nowcast_date = nowcast_date,
+                as_of_date = latest_as_of,
+                version = "latest",
+                output_dir = output_dir
+              )
+            }
+
+            as_of_dates_by_nowcast[[nowcast_date]]$latest <- as.character(latest_as_of)
+            message("    Updated ", length(unique(target_data_latest_processed$location)),
+                    " location(s)")
+          } else {
+            message("    No latest target data available, skipping")
+          }
+        }, error = function(e) {
+          warning(paste("Error updating latest targets for", nowcast_date, ":", e$message))
+        })
+      }
+    }
+  }
+
   # Generate dashboard-options.json
   message("\nGenerating dashboard-options.json...")
 


### PR DESCRIPTION
Summary: Authored by claude 

  - The weekly scheduled pipeline run (build-data.yaml, Thursdays 14:00 UTC) only processed the single
  newest nowcast date. Because the run happens just 1 day after the Wednesday nowcast date, the "latest"   available target data snapshot (from the most recent Tuesday) was identical to the round-open
  snapshot. Older nowcast dates were never revisited, so their targets/latest/ files remained frozen
  with stale round-open-era data.
  - After the main processing loop, the pipeline now identifies all nowcast dates from the last ~13
  weeks whose rounds are still open and re-fetches/re-exports their latest target data using the most
  recent available as_of snapshot. This also corrects the as_of metadata written to
  dashboard-options.json.

  Problem

  When the pipeline runs on Thursday for a Wednesday nowcast date (e.g., 2026-01-14):

  Date computed: Round-open as_of
  Function: get_round_open_as_of_date()
  Result: 2026-01-13 (Tuesday before)
  ────────────────────────────────────────
  Date computed: Latest as_of
  Function: get_latest_as_of_date()
  Result: 2026-01-13 (same Tuesday — most recent snapshot available 1 day later)

  Both resolve to the same date, so the "latest" and "round-open" target files were identical at export
  time. And since the default scheduled run only processes tail(all_nowcast_dates, 1), previously
  exported dates were never updated with genuinely newer snapshots.

  Change

  File: src/dashboard/pipeline.R (+58 lines)

  Added a new section after the main processing loop that runs when generate_targets = TRUE:

  1. Filters all_nowcast_dates to those where the round hasn't closed yet (!is_round_closed(date)) — the   last ~13 weeks
  2. Excludes dates already fully processed in the main loop (avoids redundant work)
  3. For each remaining date:
    - Fetches the most recent available target data snapshot via get_latest_as_of_date() +
  fetch_target_data()
    - Processes and re-exports targets/latest/{location}_{date}.json for all locations
    - Updates as_of_dates_by_nowcast metadata so dashboard-options.json is accurate
  4. Each date is wrapped in tryCatch (matching existing error-handling pattern) so a failure on one
  date doesn't block others

  No new functions were introduced — the implementation reuses is_round_closed(), get_clades_for_date(),   get_latest_as_of_date(), fetch_target_data(), process_daily_target_data(), and export_target_json().

  What stays the same

  - The main processing loop is untouched — new nowcast dates are still fully processed (predictions,
  quantiles, multinomial PIs, both target versions, forecasts)
  - build-data.yaml requires no changes — the existing cp -r output/targets/latest/* step already copies   whatever the pipeline generates
  - No new dependencies or configuration changes

  Test plan

  - All 852 existing tests pass (0 failures, 2 expected warnings from integration test fetching future
  dates)
  - Verify on next scheduled Thursday run that targets/latest/ files for older nowcast dates have
  updated as_of dates
  - Spot-check a few location files (e.g., CA, MA) to confirm as_of in latest JSON is newer than the
  round-open as_of