### PR TITLE
 Add hubverse-native evaluation page

### DIFF
--- a/predevals-config.yml
+++ b/predevals-config.yml
@@ -1,0 +1,71 @@
+schema_version: https://raw.githubusercontent.com/hubverse-org/hubPredEvalsData/main/inst/schema/v1.0.1/config_schema.json
+rounds_idx: 0
+targets:
+- target_id: clade_prop
+  metrics:
+  - energy_score
+  - brier_score_point
+  - brier_score_dist
+  - interval_coverage_50
+  - interval_coverage_90
+  disaggregate_by:
+  - location
+  - nowcast_date
+  - horizon
+  - target_date
+eval_sets:
+- eval_set_name: Overall
+task_id_text:
+  location:
+    AL: Alabama
+    AK: Alaska
+    AZ: Arizona
+    AR: Arkansas
+    CA: California
+    CO: Colorado
+    CT: Connecticut
+    DE: Delaware
+    DC: District of Columbia
+    FL: Florida
+    GA: Georgia
+    HI: Hawaii
+    ID: Idaho
+    IL: Illinois
+    IN: Indiana
+    IA: Iowa
+    KS: Kansas
+    KY: Kentucky
+    LA: Louisiana
+    ME: Maine
+    MD: Maryland
+    MA: Massachusetts
+    MI: Michigan
+    MN: Minnesota
+    MS: Mississippi
+    MO: Missouri
+    MT: Montana
+    NE: Nebraska
+    NV: Nevada
+    NH: New Hampshire
+    NJ: New Jersey
+    NM: New Mexico
+    NY: New York
+    NC: North Carolina
+    ND: North Dakota
+    OH: Ohio
+    OK: Oklahoma
+    OR: Oregon
+    PA: Pennsylvania
+    PR: Puerto Rico
+    RI: Rhode Island
+    SC: South Carolina
+    SD: South Dakota
+    TN: Tennessee
+    TX: Texas
+    UT: Utah
+    VT: Vermont
+    VA: Virginia
+    WA: Washington
+    WV: West Virginia
+    WI: Wisconsin
+    WY: Wyoming


### PR DESCRIPTION


  ##Summary: By Claude

  - Adds `predevals-config.yml` to configure the hubverse predevals evaluation module
  - The site builder will auto-generate `eval.html` on the next site rebuild — no custom QMD or
  JavaScript needed
  - Scores data and `predevals-options.json` are already live on the `predevals/data` branch

  ## What the eval page will show

  An interactive scores explorer with:
  - A table of overall scores per model across the full season
  - Disaggregated views broken down by location, nowcast date, horizon, and target date

  ## Config details (predevals-config.yml)

  - Target: clade_prop
  - Metrics: energy_score, brier_score_point, brier_score_dist, interval_coverage_50,
  interval_coverage_90
  - Eval set: "Overall" (single set, no seasonal splits for this hub)
  - Disaggregations: location, nowcast_date, horizon, target_date
  - Full task_id_text mapping for all 52 US state/territory codes
 Once this PR is merged, need to check that the eval page shows on the dashboard after site rebuild.
Future work includes automating adding new scores and adding relative scores with respect to the baseline