### PR TITLE
Add Pango lineage names to clade labels

### DIFF
--- a/.github/workflows/build-data.yaml
+++ b/.github/workflows/build-data.yaml
@@ -72,6 +72,7 @@ jobs:
             any::readr
             any::tibble
             any::arrow
+            any::yaml
             github::hubverse-org/hubData
             github::hubverse-org/hubUtils
 

--- a/src/dashboard/config.R
+++ b/src/dashboard/config.R
@@ -14,8 +14,8 @@ TARGET_DATA_API_URL <- "https://api.github.com/repos/reichlab/variant-nowcast-hu
 # Maximum weeks after nowcast date that target data is available
 TARGET_DATA_MAX_WEEKS <- 13
 
-# Clade Labels
-CLADE_LABELS_URL <- "https://nextstrain.org/charon/getSourceInfo?prefix=nextstrain.org/ncov/gisaid/global/all-time"
+# Clade Labels — Nextstrain crosswalk of clade IDs to display names (includes Pango lineage)
+CLADE_LABELS_URL <- "https://raw.githubusercontent.com/nextstrain/ncov/master/defaults/clade_display_names.yml"
 
 # Quantile Configuration
 # For 50%, 80%, 95% prediction intervals

--- a/src/dashboard/pipeline.R
+++ b/src/dashboard/pipeline.R
@@ -56,18 +56,22 @@ get_clades_for_date <- function(hub_config, nowcast_date) {
   unlist(hub_config$rounds$model_tasks[[round_idx]]$task_ids$clade$required)
 }
 
-#' Get clade labels (identity mapping - clade name is the label)
+#' Fetch clade display labels from Nextstrain crosswalk
+#' Maps clade IDs (e.g. "24A") to display strings with Pango lineage (e.g. "24A (JN.1)").
+#' Falls back to an empty tibble (identity mapping) if the URL is unreachable.
 #' @return Tibble with clade and clade_label columns
 fetch_clade_labels <- function() {
-
-  # For now, use identity mapping (clade = label)
-
-  # Could be enhanced to fetch from Nextstrain API if needed
-
-  tibble::tibble(
-    clade = character(0),
-    clade_label = character(0)
-  )
+  tryCatch({
+    raw <- yaml::read_yaml(CLADE_LABELS_URL)
+    tibble::tibble(
+      clade       = names(raw),
+      clade_label = unlist(raw, use.names = FALSE)
+    )
+  }, error = function(e) {
+    warning("Could not fetch clade labels from Nextstrain: ", e$message,
+            ". Falling back to identity mapping.")
+    tibble::tibble(clade = character(0), clade_label = character(0))
+  })
 }
 
 #' Fetch target data (observed clade counts) from GitHub hub repo
@@ -658,9 +662,15 @@ run_pipeline <- function(
   # Generate dashboard-options.json
   message("\nGenerating dashboard-options.json...")
 
-  # Get clade labels for all clades used (identity mapping: clade = label)
+  # Get clade labels, enriched with Pango lineage names where available.
+  # Clades not in the Nextstrain crosswalk (e.g. "other") fall back to identity.
   all_clades <- unique(unlist(clades_by_date))
-  clade_labels_vec <- stats::setNames(all_clades, all_clades)
+  clade_label_df <- fetch_clade_labels()
+  label_lookup <- stats::setNames(clade_label_df$clade_label, clade_label_df$clade)
+  clade_labels_vec <- stats::setNames(
+    ifelse(all_clades %in% names(label_lookup), label_lookup[all_clades], all_clades),
+    all_clades
+  )
 
   export_options_json(
     locations = US_LOCATIONS,


### PR DESCRIPTION


Closes #98.

## Summary: By Claude

- Clades are now displayed as **"24A (JN.1)"** instead of **"24A"** throughout
  the dashboard (sidebar checkboxes and subplot titles).
- Uses the [Nextstrain `clade_display_names.yml` crosswalk](https://raw.githubusercontent.com/nextstrain/ncov/master/defaults/clade_display_names.yml)
  as the label source.
- Clades not in the crosswalk (e.g. `"other"`) continue to display as-is.
- The frontend (`explore.qmd`) needed no changes — it already reads
  `config.clade_labels[clade]` with an identity fallback.

## Files changed

| File | Change |
|---|---|
| `src/dashboard/config.R` | Update `CLADE_LABELS_URL` to GitHub raw URL for `clade_display_names.yml` |
| `src/dashboard/pipeline.R` | Implement `fetch_clade_labels()` with `yaml::read_yaml()` + tryCatch fallback; update `clade_labels_vec` to use label lookup |
| `.github/workflows/build-data.yaml` | Add `any::yaml` to R dependencies |

## Test plan

- [ ] Run existing tests: `Rscript -e 'testthat::test_dir("src/dashboard/tests", stop_on_failure = TRUE)'` — should pass unchanged (tests check key presence, not string values)
- [ ] Manually run `run_pipeline()` and verify `output/dashboard-options.json` contains `"24A": "24A (JN.1)"` in `clade_labels`
- [ ] Confirm `"other"` maps to `"other"` (identity fallback)
- [ ] Confirm dashboard clade checkboxes and subplot titles show Pango names after next deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)