### PR TITLE
Fix invalid cron range in update-eval-scores workflow

### DIFF
--- a/.github/workflows/update-eval-scores.yaml
+++ b/.github/workflows/update-eval-scores.yaml
@@ -5,8 +5,9 @@ name: "Update Evaluation Scores"
 
 on:
   schedule:
-    - cron: "0 16 * 3-11 5"   # Noon EDT (UTC-4), Mar–Nov
-    - cron: "0 17 * 11-3 5"   # Noon EST (UTC-5), Nov–Mar
+    - cron: "0 16 * 3-11 5"    # Noon EDT (UTC-4), Mar–Nov
+    - cron: "0 17 * 1-3 5"     # Noon EST (UTC-5), Jan–Mar
+    - cron: "0 17 * 11,12 5"   # Noon EST (UTC-5), Nov–Dec
   workflow_dispatch:
     inputs:
       publish:


### PR DESCRIPTION
GitHub Actions does not support wrap-around month ranges (e.g. 11-3). Split the EST schedule into two separate entries: 1-3 and 11,12 to fix bug.