### PR TITLE
Fix logit transform crash for mean-only models (e.g. LANL)

### DIFF
--- a/pages/explore.qmd
+++ b/pages/explore.qmd
@@ -692,6 +692,7 @@ modelColorMap = {
 logit = (p) => Math.log(p / (1 - p))
 
 logitTransform = (values) => {
+  if (!values) return values;
   return values.map(p => {
     if (p === null || p === undefined || isNaN(p)) return null;
     const clamped = Math.max(0.001, Math.min(0.999, p));


### PR DESCRIPTION
logitTransform was calling .map() on undefined when a model has no quantile columns (LANL-CovTransformer, CADPH-CATaLog). Adding a null guard returns undefined unchanged, letting the existing hasValidIntervals check correctly suppress the interval ribbon. Co-authored by Claude. Should (hopefully) fix the issue in #122.