### PR TITLE
Add Plausible analytics

### DIFF
--- a/site-config.yml
+++ b/site-config.yml
@@ -122,3 +122,13 @@ pages:
       href: "2024-12-04-report.md"
     - text: "2024-11-27"
       href: "2024-11-27-report.md"
+
+html:
+  include-after-body:
+    - text: |
+        <!-- Privacy-friendly analytics by Plausible -->
+        <script async src="https://plausible.io/js/pa-DOosbUzSYYO66nV9P5iOt.js"></script>
+        <script>
+          window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};
+          plausible.init()
+        </script>


### PR DESCRIPTION
Adds privacy-friendly Plausible analytics by injecting the shared reichlab.io tracking snippet into `<head>`. Part of consolidating all reichlab.io sites under a single Plausible site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)